### PR TITLE
Sensor IMX728 addition

### DIFF
--- a/include/tiovx_sensor_module.h
+++ b/include/tiovx_sensor_module.h
@@ -113,6 +113,7 @@ typedef struct {
      * SENSOR_ONSEMI_AR0233_UB953_MARS
      * SENSOR_SONY_IMX219_RPI
      * SENSOR_OV2312_UB953_LI
+     * SENSOR_SONY_IMX728
      *
      * */
     vx_char sensor_name[ISS_SENSORS_MAX_NAME];

--- a/src/tiovx_sensor_module.c
+++ b/src/tiovx_sensor_module.c
@@ -102,6 +102,10 @@ vx_status tiovx_init_sensor(SensorObj *sensorObj, char *objName)
     {
         sensorObj->sensorParams.dccId=2312;
     }
+    else if(strcmp(sensorObj->sensor_name, "SENSOR_SONY_IMX728") == 0)
+    {
+        sensorObj->sensorParams.dccId=728;
+    }
     else
     {
         TIOVX_MODULE_ERROR("[SENSOR-MODULE] Invalid sensor name\n");


### PR DESCRIPTION
GST code uses these functions to run the ISP pipe and therefore, it'll need to recognise the specifics of the camera we're using.